### PR TITLE
add autoReconnectRecreateClient option

### DIFF
--- a/bot.js
+++ b/bot.js
@@ -35,6 +35,7 @@ const createBot = (conf = {}) => {
 		errorHandler: (error, context) => console.error('MailBot Error', context, error), // eslint-disable-line no-console
 		autoReconnect: true,
 		autoReconnectTimeout: 5000,
+		autoReconnectRecreateClient: false,
 		streamAttachments: true,
 		removeTextSignature: true,
 		ignoreAttachmentsInSignature: true,
@@ -176,6 +177,11 @@ const createBot = (conf = {}) => {
 			debug('IMAP disconnected', err)
 			if (err && conf.autoReconnect) {
 				debug('Trying to reconnect…')
+				if(conf.autoReconnectRecreateClient) {
+					debug('Recreate client')
+					client = imap(conf.imap)
+					initClient()
+				}
 				setTimeout(() => client.connect(), conf.autoReconnectTimeout)
 			} else {
 				debug('No reconnection (user close or no autoReconnect)')


### PR DESCRIPTION
Auto-reconnect hangs when internet connection established back on my Mac machine and on my Linux server. 

![image](https://user-images.githubusercontent.com/5621185/33151971-f61ced40-cfe2-11e7-86eb-2b53c38dea9d.png)

I have added an option to recreate imap client when reconnecting to solve this problem. 

This option disabled by default for backward compatibility but can be enabled if anyone has same issue.

